### PR TITLE
Update fares.md; misc cleanup throughout

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ consistent with [GTFS]
 -  `0.2.7`: eliminates `fare_class` as an optional variable in `routes_ft.txt` to eliminate ambiguity
 -  `0.2.8`: requires `transfers_ft` because it has distance. Blank `schedule_precedence` is no precedence either way.  Defaults times in `fare_rules_ft` can have label `default`.
 -  `0.2.9`: many clarifications. Use `lot_lon` rather than `lot_long` in `drive_access_points_ft` for GTFS consistency.  
--  `0.3.0`: clarifications. Changed definition of `end_time`. Renamed `fare_class` to `fare_period`. Made optional files optional.
+-  `0.3.0`: clarifications. Changed definition of `end_time`. Renamed `fare_class` to `fare_period`. Made optional files optional. 
 
 # Specification
 
@@ -74,7 +74,7 @@ Filename 					| Description
 [`stop_times_ft.txt`](/files/stop_times_ft.md)	                    | additional transit trip stop time information	 
 [`fare_attributes_ft.txt`](/files/fare_attributes_ft.md)			| fare attributes  
 [`fare_rules.txt`](/files/fare_rules.md)							| fare rules  
-[`fare_rules_ft.txt`](/files/fare_rules_ft.md)						| additional fare rules  
+[`fare_periods_ft.txt`](/files/fare_periods_ft.md)						| additional fare rules  
 [`fare_transfer_rules_ft.txt`](/files/fare_transfer_rules_ft.md)	| fare transfer rules  
 [`zones_ft.txt`](/files/zones_ft.md)	                            | zone locations 
 

--- a/fares.md
+++ b/fares.md
@@ -4,72 +4,63 @@
 
 Fares can be quite complex.  This page illustrates examples of how to specify them.
 
-#### Single leg, no transfer, flat fare
+### Single leg, no transfer, flat fare
 
 The example below illustrates how the fare for a single leg transit trip using a service 
-that has flat fare system. First `fare_rules.txt` is queried on `route_id`, `origin_zone` & 
-`destination_zone` to return it’s `fare_id`.  In this case, Origin and destination zones 
-have values of None, which represent cases where stops are never used in a zonal fee 
-structure. `Fare_rules_ft.txt` is then queried on `fare_id` and the time of departure (>= to 
-`start_time`, <= `end_time`) to return `fare_period`. `Fare_attributes_ft.txt` is then queried 
-on `fare_period`, and the cost of the fare is returned by the price field. 
+that has flat fare system. First [`fare_rules.txt`](../fare_rules.md) is queried on `route_id`, `origin_zone` & 
+`destination_zone` to return it’s `fare_id`.  In this case, origin and destination zones have a value of None, which represents cases where stops are never used in a zonal fee 
+structure. Then, [`fare_periods_ft.txt`](../fare_periods_ft.md) is queried on `fare_id` and the time of departure (>= to 
+`start_time`, <= `end_time`) to return `fare_period`. Finally, [`fare_attributes_ft.txt`](../fare_attributes_ft.md) is queried 
+on `fare_period`, and the cost of the fare is returned by the `price` field. 
 
 *[`stops.txt`](/files/stops.md)*
 
 `stop_id` 	| `stop_name` 	| `zone_id`	| ...										
 --------- 	| -----	 		| -----	   	| -----	
 1 			| 14th/Mission 	| - 		| ...
-1 			| 30th/Mission 	| - 		| ...
-
-*[`routes_ft.txt`](/files/routes_ft.md)*
-
-`route_id`	| `mode` 		| `fare_period` 	| `proof_of_payment`										
-----------	| -----	 		| -----	    	| -----	
-MUN14  		| `local_bus` 	| muni-local 	| 1
-MUN14R 		| `rapid_bus` 	| muni-local 	| 1
+2 			| 30th/Mission 	| - 		| ...
 
 *[`fare_rules.txt`](/files/fare_rules.md)*
 
-`fare_id` 		| `route_id` 	| `contains_id`											
---------- 		| -----	 		| -----	   		
-muni-allday	| muni-local 	| - 			
+`fare_id` 		| `route_id`
+--------- 		| -----
+muni-local	| MUN14
 
-*[`fare_rules_ft.txt`](/files/fare_rules_ft.md)*
+*[`fare_periods_ft.txt`](/files/fare_periods_ft.md)*
 
 `fare_id` 		| `fare_period` 	| `start_time`	| `end_time`											
 --------- 		| -----	 		| -----	  		| ---- 		
-muni-allday		| muni-local 	| 00:00:01 		| 24:00:00 	
+muni-local		| muni-allday 	| 00:00:01 		| 24:00:00 	
 
 *[`fare_attributes_ft.txt`](/files/fare_attributes_ft.md)*
 
 `fare_period`	| `price` 	| `currency_type`	| `transfers`	| `transfer_duration`											
 --------- 		| -----	 	| -----	 			| -----			| -----  		
-muni-local		| 2.50 		| USD 				| -				| 5400
+muni-allday		| 2.50 		| USD 				| -				| 5400
 
-#### Two or more legs, transfer
+### Two or more legs, transfer
 
 To capture the cost of this scenario, the cost of each leg is calculated using the same 
-method proposed for a single leg trip. We then use the from `fare_period` and the to 
-`fare_period` to get the `is_flat_fee` and `transfer_rule` attributes from 
-`fare_transfer_rules.txt`. `is_flat_fee` is a boolean that indicates if the transfer is
-percentage- or flat-fee based. For example, if `is_flat_fee` is True, the fare for the 
-second leg of the trip is the amount in `tranfer_rule` (e.g., 1.50). To indicate a free 
-transfer, `reduced_rate `is set to True and `tranfer_rule` is set to 0.
+method proposed for a single leg trip. We then use the *from* `fare_period` and the *to* 
+`fare_period` to get the `transfer_fare_type`, which has three possible values: `transfer_cost`, `transfer_discount`, or `transfer_free`. The transfer is free if the value of this field is `transfer_free`. If `transfer_discount`, the amount in the `transfer_fare` field is subtracted from the the full cost of the fare of the to leg. If `transfer_cost`, the full amount of the `transfer_fare` field is the cost of the transfer.
 
-#### Systemwide Fare
+### Multiple Transfers
+A second transfer would work in a similar fashion, however, it is possible (unlikely ?) that the fare would have to be calculated using the *from* `fare_period` for both the first and second leg to determine which `transfer_rule` to use. For example, a rider uses the same `fare_period` in the first and third leg of a three leg trip. This `fare_period` is entitled to a free transfer (`transfer_fare_type` = `transfer_free`) when staying with the same fare_period during a transfer (e.g. a metro bus to metro bus transfer). Assuming the transfer has not expired (and this scenario is permitted), the rider is eligible for a free transfer based on the `fare_period` associated with the first leg of the trip, even if there is a transfer cost associated with the second and third leg.  
+
+### Systemwide Fare
 The following two-leg (one transfer) trip demonstrates how a system-wide fare would be 
-calculated using Pierce Transit as an example. First, `fare_rules.txt` is queried on the 
+calculated using Pierce Transit as an example. First, [`fare_rules.txt`](../fare_rules.md) is queried on the 
 `route_id`, `origin_zone` and `destination_zone` of the first leg to return it’s `fare_id`.  In 
-this case, Origin and destination have zones but are the same because these stops need 
-zones for Sound Transit, our regional express bus service. `Fare_rules_ft.txt` is then 
+this case, origin and destination have zones but are the same because these stops need 
+zones for Sound Transit, our regional express bus service. Then [`fare_rules_ft.txt`](../fare_rules_ft.md) is 
 queried on `fare_id` and the time of departure (>= to `start_time`, <= `end_time`) to return 
-`fare_period`. `Fare_attributes_ft.txt` is then queried on `fare_period`, and the cost of the fare 
+`fare_period`. Next, [`fare_attributes_ft.txt`](../fare_attributes_ft.md) is queried on `fare_period`, and the cost of the fare 
 is returned by the `price` field. 
 
 The next step is to determine the transfer rule for this particular transfer. We use the 
 `route_id` of the second leg to get the `fare_id` which, along with departure time, is used 
-to get `fare_period` from `fare_rules_ft.txt`. The `from_fare_period`  and the `to_fare_period` are used 
-to get `reduced_rate` and `transfer_cost` from `fare_transfer_rules.txt`. In this case 
+to get `fare_period` from [`fare_rules_ft.txt`. The `from_fare_period`  and the `to_fare_period` are used 
+to get `reduced_rate` and `transfer_cost` from [`fare_transfer_rules_ft.txt`](../fare_transfer_rules_ft.md). In this case 
 `reduced_rate` is True the and `fare_cost` is 0 indicating that there is no fee for the second 
 leg of this trip. 
 
@@ -139,13 +130,13 @@ Pierce-Local	| Pierce-AllDay 	| 00:00:01 		| 24:00:00
 --------- 		| -----	 	| -----	 			| -----			| -----  		
 Pierce-Allday	| 2.00 		| USD 				| -				| 1
 
-*[`fare_transfer_rules.txt`](/files/fare_transfer_rules.md)*
+*[`fare_transfer_rules_ft.txt`](/files/fare_transfer_rules_ft.md)*
 
 `from_fare_period` 	| `to_fare_period` 	| `sis_flat_fee`| `transfer_rule`											
 --------- 			| -----	 			| -----	  		| ---- 		
 Pierce-AllDay		| Pierce-AllDay 	| False			| 0	
 
-#### Zone-Based Fares
+### Zone-Based Fares
 Commuter rail frequently calculates fares based on the number of zones you traverse.  This 
 can be specified as follows.
 
@@ -175,7 +166,7 @@ SOUNDER-2Z	| Sounder-2Z-AllDay | 00:00:01 		| 24:00:00
 --------- 			| -----	 	| -----	 			| -----			| -----  		
 Sounder-2Z-AllDay	| 2.00 		| USD 				| -				| 1
 
-#### Zone-Based Fares; Peak Fares
+### Zone-Based Fares; Peak Fares
 Origin-destination based fares are common on heavy rail systems, such as BART.  They are 
 a special case of zone-based fares, where every station has its own zone, and could be 
 specified as follows.  This example also shows the use of peak fares.

--- a/fares.md
+++ b/fares.md
@@ -1,14 +1,12 @@
-﻿##Fares
-
-***WARNING - THIS FILE NEEDS EXTENSIVE REVIEW AND CORRECTION***
-
+## Fares
 Fares can be quite complex.  This page illustrates examples of how to specify them.
 
 ### Single leg, no transfer, flat fare
 
 The example below illustrates how the fare for a single leg transit trip using a service 
 that has flat fare system. First [`fare_rules.txt`](../fare_rules.md) is queried on `route_id`, `origin_zone` & 
-`destination_zone` to return it’s `fare_id`.  In this case, origin and destination zones have a value of None, which represents cases where stops are never used in a zonal fee 
+`destination_zone` to return it’s `fare_id`.  In this case, origin and destination zones have a value of None, 
+which represents cases where stops are never used in a zonal fee 
 structure. Then, [`fare_periods_ft.txt`](../fare_periods_ft.md) is queried on `fare_id` and the time of departure (>= to 
 `start_time`, <= `end_time`) to return `fare_period`. Finally, [`fare_attributes_ft.txt`](../fare_attributes_ft.md) is queried 
 on `fare_period`, and the cost of the fare is returned by the `price` field. 
@@ -30,7 +28,7 @@ muni-local	| MUN14
 
 `fare_id` 		| `fare_period` 	| `start_time`	| `end_time`											
 --------- 		| -----	 		| -----	  		| ---- 		
-muni-local		| muni-allday 	| 00:00:01 		| 24:00:00 	
+muni-local		| muni-allday 	| 00:00:00 		| 24:00:00 	
 
 *[`fare_attributes_ft.txt`](/files/fare_attributes_ft.md)*
 
@@ -50,23 +48,21 @@ A second transfer would work in a similar fashion, however, it is possible (unli
 ### Systemwide Fare
 The following two-leg (one transfer) trip demonstrates how a system-wide fare would be 
 calculated using Pierce Transit as an example. First, [`fare_rules.txt`](../fare_rules.md) is queried on the 
-`route_id`, `origin_zone` and `destination_zone` of the first leg to return it’s `fare_id`.  In 
-this case, origin and destination have zones but are the same because these stops need 
-zones for Sound Transit, our regional express bus service. Then [`fare_rules_ft.txt`](../fare_rules_ft.md) is 
+`route_id`, `origin_zone` and `destination_zone` of the first leg to return its `fare_id`.  In 
+this case, the origin and destination have zones but are the same because these stops need 
+zones for Sound Transit, our regional express bus service. Then [`fare_periods_ft.txt`](../fare_periods_ft.md) is 
 queried on `fare_id` and the time of departure (>= to `start_time`, <= `end_time`) to return 
 `fare_period`. Next, [`fare_attributes_ft.txt`](../fare_attributes_ft.md) is queried on `fare_period`, and the cost of the fare 
 is returned by the `price` field. 
 
 The next step is to determine the transfer rule for this particular transfer. We use the 
 `route_id` of the second leg to get the `fare_id` which, along with departure time, is used 
-to get `fare_period` from [`fare_rules_ft.txt`. The `from_fare_period`  and the `to_fare_period` are used 
-to get `reduced_rate` and `transfer_cost` from [`fare_transfer_rules_ft.txt`](../fare_transfer_rules_ft.md). In this case 
-`reduced_rate` is True the and `fare_cost` is 0 indicating that there is no fee for the second 
-leg of this trip. 
+to get `fare_period` from [`fare_periods_ft.txt`](../fare_periods_ft.md). The `from_fare_period`  and the `to_fare_period` are used 
+to get `tranfer_fare_type` and `transfer_far` from [`fare_transfer_rules_ft.txt`](../fare_transfer_rules_ft.md). In this case `transfer_fare_type` is `transfer_free` indicating that there is no fee for the second leg of this trip. 
 
-**First Leg**
+**First Leg:**
 
-*[`stops.txt`](/files/stops.md)*
+*[`stops.txt`](/`file`s/stops.md)*
 
 `stop_id` 	| `stop_name` 				| `zone_id`	| ...										
 --------- 	| -----	 					| -----	   	| -----	
@@ -75,29 +71,29 @@ leg of this trip.
 
 *[`routes_ft.txt`](/files/routes_ft.md)*
 
-`route_id`	| `mode` 		| `fare_period` 	| `proof_of_payment`										
-----------	| -----	 		| -----	    	| -----	
-PT01  		| `local_bus` 	| Pierce 		| 1
+`route_id`	| `mode` 		| `proof_of_payment`										
+----------	| -----	 		| -----	
+PT01  		| `local_bus` | 1
 
 *[`fare_rules.txt`](/files/fare_rules.md)*
 
 `fare_id` 		| `route_id`	| `origin_id`	| `destination_id`										
 --------- 		| -----	 		| -----	   		| -----
-Pierce-Local	| PT0`			| Pierce		| Pierce
+Pierce-Local	| PT01			| Pierce		| Pierce
 
 *[`fare_rules_ft.txt`](/files/fare_rules_ft.md)*
 
 `fare_id` 		| `fare_period` 		| `start_time`	| `end_time`											
 --------- 		| -----	 			| -----	  		| ---- 		
-Pierce-Local	| Pierce-AllDay 	| 00:00:01 		| 24:00:00 	
+Pierce-Local	| Pierce-AllDay 	| 00:00:00 		| 24:00:00 	
 
 *[`fare_attributes_ft.txt`](/files/fare_attributes_ft.md)*
 
 `fare_period`	| `price` 	| `currency_type`	| `transfers`	| `payment_method`											
 --------- 		| -----	 	| -----	 			| -----			| -----  		
-Pierce-Allday	| 2.00 		| USD 				| -				| 1
+Pierce-AllDay	| 2.00 		| USD 				| -				| 1
 
-**Second Leg**
+**Second Leg:**
 
 *[`stops.txt`](/files/stops.md)*
 
@@ -108,33 +104,98 @@ Pierce-Allday	| 2.00 		| USD 				| -				| 1
 
 *[`routes_ft.txt`](/files/routes_ft.md)*
 
-`route_id`	| `mode` 		| `fare_period` 	| `proof_of_payment`										
-----------	| -----	 		| -----	    	| -----	
-PT53  		| local_bus 	| Pierce		| 1
+`route_id`	| `mode` 		| `proof_of_payment`										
+----------	| -----	 		| -----	
+PT53  		| local_bus 	| 1
 
 *[`fare_rules.txt`](/files/fare_rules.md)*
 
 `fare_id` 		| `route_id`	| ...										
 --------- 		| -----	 		| -----	   		
-Pierce-Local	| `PT04`		| ...
+Pierce-Local	| `PT53`		| ...
 
 *[`fare_rules_ft.txt`](/files/fare_rules_ft.md)*
 
 `fare_id` 		| `fare_period` 		| `start_time`	| `end_time`											
 --------- 		| -----	 			| -----	  		| ---- 		
-Pierce-Local	| Pierce-AllDay 	| 00:00:01 		| 24:00:00 	
+Pierce-Local	| Pierce-AllDay 	| 00:00:00 		| 24:00:00 	
 
 *[`fare_attributes_ft.txt`](/files/fare_attributes_ft.md)*
 
 `fare_period`	| `price` 	| `currency_type`	| `transfers`	| `payment_method`											
 --------- 		| -----	 	| -----	 			| -----			| -----  		
-Pierce-Allday	| 2.00 		| USD 				| -				| 1
+Pierce-AllDay	| 2.00 		| USD 				| -				| 1
 
 *[`fare_transfer_rules_ft.txt`](/files/fare_transfer_rules_ft.md)*
 
-`from_fare_period` 	| `to_fare_period` 	| `sis_flat_fee`| `transfer_rule`											
+`from_fare_period` 	| `to_fare_period` 	| `transfer_fare_type`| `transfer_fare`											
 --------- 			| -----	 			| -----	  		| ---- 		
-Pierce-AllDay		| Pierce-AllDay 	| False			| 0	
+Pierce-AllDay		| Pierce-AllDay 	| `transfer_free`			| 0	
+
+### Inter-Agency Fare, zonal fee structure
+The following illustrates how an inter-agency fare (one transfer, two different fare classes) would be calculated. First, [`fare_rules.txt`](../fare_rules.md) is queried on the `route_id`, `origin_zone` and `destination zone` of the first leg to return its `fare_id`. Then [`fare_periods_ft.txt`](../fare_periods_ft.md) is queried on `fare_id` and the time of departure (>= to `start_time`, <= `end_time`) to return `fare_period`. Next, [`fare_attributes_ft.txt`](../fare_attributes_ft.md) is queried on `fare_period`, and the cost of the fare is returned by the `price` field.
+
+The next step is to determine the transfer rule for this particular transfer. We use the `route_id` of the second leg to get the `fare_id` which can then be used to get `fare_period`. We then get the rule that applies to this transfer, which is returned by querying [`fare_transfer_rules_ft.txt`](../fare_transfer_rules_ft.md) on `from_fare_period` and `to_fare_period`. In this case, the field `transfer_fare_type` in the returned record is `transfer_cost`, indicating the amount in the `transfer_fare` field is the cost of the transfer.
+
+**First Leg:**
+
+*[`stops.txt`](../stops.md)* 
+
+`stop_id` | `stop_name` | `zone_id` | ...
+----- | -----	| -----	| -----	
+1 | TACOMA_DOME | Tacoma | ...
+2 | 4th Ave & Cherry | Seattle | ...
+
+*[`fare_rules.txt`](../fare_rules.md)*
+
+`fare_id` | `origin_id` | `contains_id`
+----- 	| -----	| -----	
+ST_EXPRESS  | Tacoma | 0
+
+*[`fare_periods_ft.txt`](../fare_periods_ft.md)*
+
+`fare_id` | `fare_period` | `start_time` | `end_time` 
+----- | -----	| -----	| -----	
+ST_EXPRESS | ST_EXPRESS_2Z | 00:00:00 | 24:00:00
+
+*[`fare_attributes_ft.txt`](../fare_attributes_ft.md)* 
+
+`fare_period` | `price` | `currency_type` | `payment_method` | `transfers`
+----- | -----	| -----	| -----	| -----	
+ST_EXPRESS_2Z | 3.40 | USD | 1 | 2
+
+**Second leg:**
+
+*[`stops.txt`](../stops.md)*
+
+`stop_id` | `stop_name` | `zone_id` | ...
+----- | -----	| -----	| -----	
+3 | James St. & 3rd Ave. | Seattle | ...
+4 | E Jefferson St & 17th Ave | Seattle | ...
+
+*[`fare_rules.txt`](../fare_rules.md)* 
+
+`fare_id` | `origin_id` | `destination_id`
+----- 	| -----	| -----	
+Metro_1Z | Seattle | Seattle
+
+*[`fare_periods_ft.txt`](../fare_periods_ft.md)*
+
+`fare_id` | `fare_period` | `start_time` | `end_time`
+----- | -----	| -----	| -----	
+Metro_1Z | METRO_1Z_P | 06:00:00 | 09:00:00
+
+*[`fare_attributes_ft.txt`](../fare_attributes_ft.md)*
+
+`fare_period` | `price` | `currency_type` | `payment_method` | `transfers`
+----- | -----	| -----	| -----	| -----	
+Metro_1Z_P | 2.75 | USD | 1 | -
+
+*[`fare_transfer_rules_ft.txt`](../fare_transfer_rules_ft.md)*
+
+`from_fare_period` | `to_fare_period` | `transfer_fare_type` | `transfer_fare`
+----- | -----	| -----	| -----	
+ST_EXPRESS_2Z | Metro_1Z_P | False | 1
 
 ### Zone-Based Fares
 Commuter rail frequently calculates fares based on the number of zones you traverse.  This 
@@ -143,22 +204,21 @@ can be specified as follows.
 *[`stops.txt`](/files/stops.md)*
 
 `stop_id` 	| `stop_name` 	| `zone_id`	| ...										
---------- 	| -----	 		| -----	   	| -----	
+----- 	| -----	 		| -----	   	| -----	
 1 			| PIONEER_SQ 	| Seattle	| ...
 2			| EVERETT		| Everett	| ...
 
 *[`fare_rules.txt`](/files/fare_rules.md)*
 
 `fare_id` 		| `origin_id`	| `destination_id`										
---------- 		| -----	 		| -----	   		
+------ 		| -----	 		| -----	   		
 SOUNDER-2Z	| Seattle		| Everett
 
 *[`fare_rules_ft.txt`](/files/fare_rules_ft.md)*
 
 `fare_id` 	| `fare_period` 		| `start_time`	| `end_time`											
 --------- 	| -----	 			| -----	  		| ---- 		
-SOUNDER-2Z	| Sounder-2Z-AllDay | 00:00:01 		| 24:00:00 	
-
+SOUNDER-2Z	| Sounder-2Z-AllDay | 00:00:00 		| 24:00:00 	
 
 *[`fare_attributes_ft.txt`](/files/fare_attributes_ft.md)*
 
@@ -166,10 +226,10 @@ SOUNDER-2Z	| Sounder-2Z-AllDay | 00:00:01 		| 24:00:00
 --------- 			| -----	 	| -----	 			| -----			| -----  		
 Sounder-2Z-AllDay	| 2.00 		| USD 				| -				| 1
 
-### Zone-Based Fares; Peak Fares
+### OD-Based Fares
 Origin-destination based fares are common on heavy rail systems, such as BART.  They are 
 a special case of zone-based fares, where every station has its own zone, and could be 
-specified as follows.  This example also shows the use of peak fares.
+specified as follows.
 
 *[`stops.txt`](/files/stops.md)*
 
@@ -184,18 +244,14 @@ specified as follows.  This example also shows the use of peak fares.
 --------- 	| -----	 		| -----	   		
 B-EMB-FRE	| B-EMB		| B-FRE
 
-*[`fare_rules_ft.txt`](/files/fare_rules_ft.md)*
+*[`fare_periods_ft.txt`](/files/fare_periods_ft.md)*
 
 `fare_id` 	| `fare_period` 		| `start_time`	| `end_time`											
 --------- 	| -----	 			| -----	  		| ---- 		
-B-EMB-FRE	| B-EMB-FRE-AllDay	| 00:00:01 		| 24:00:00 	
-B-EMB-FRE	| B-EMB-FRE-AMPeak	| 07:00:00 		| 08:30:00 	
-B-EMB-FRE	| B-EMB-FRE-PMPeak	| 17:00:00 		| 18:30:00 
+B-EMB-FRE	| B-EMB-FRE-AllDay	| 00:00:00 		| 24:00:00 	
 
 *[`fare_attributes_ft.txt`](/files/fare_attributes_ft.md)*
 
 `fare_period`		| `price` 	| `currency_type`	| `transfers`	| `payment_method`											
 --------- 			| -----	 	| -----	 			| -----			| -----  		
 B-EMB-FRE-AllDay	| 2.75 		| USD 				| -				| 1
-B-EMB-FRE-AMPeak	| 4.75 		| USD 				| -				| 1
-B-EMB-FRE-PMPeak	| 4.75 		| USD 				| -				| 1

--- a/files/agency.md
+++ b/files/agency.md
@@ -14,7 +14,7 @@ Required Attributes	| Description
 `agency_id`			| ID that uniquely identifies the transit agency.
 `agency_name`		| Contains full name of transit agency.
 `agency_url`		| String. Fully qualified URL of agency.
-`agency_timezone`	| String. [List of valid values](http//en.wikipedia.org/wiki/List_of_tz_database_time_zones)
+`agency_timezone`	| String. [List of valid values](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones)
 
 File MAY contain the following attributes:
 

--- a/files/calendar.md
+++ b/files/calendar.md
@@ -2,7 +2,7 @@
 Filename: `calendar.txt`
 
  *  Filename MUST be `calendar.txt`
- *  File MUST contain a record for each service category used in `trips.txt`
+ *  File MUST contain a record for each service category used in [`trips.txt`](../trips.md)
  *  File MUST be a valid CSV file.
  *  The first line of each file MUST contain case-sensitive field names.
  *  Field names MUST NOT contain tabs, carriage returns or new lines.
@@ -12,8 +12,8 @@ File MUST contain the following attributes:
 Required Attributes	| Description										
 ----------			| -------------		
 `service_id`		| ID that uniquely identifies the transit agency.
-`start_date`		| Start date of service in YYYMMDD format.  
-`end_date`			| End date of service [ which is included in the service interval ] in YYYMMDD format.  
+`start_date`		| Start date of service in YYYYMMDD format.  
+`end_date`			| End date of service [ which is included in the service interval ] in YYYYMMDD format.  
 `monday`			| 0 or 1. Binary value on whether this service pattern is available on Mondays.
 `tuesday`			| 0 or 1. Binary value on whether this service pattern is available on Tuesdays.
 `wednesday`			| 0 or 1. Binary value on whether this service pattern is available on Wednesdays.

--- a/files/fare_attributes_ft.md
+++ b/files/fare_attributes_ft.md
@@ -9,29 +9,29 @@ Examples of how to specify various fare schemes can be found in the [fares page]
  *  Field names MUST NOT contain tabs, carriage returns or new lines.
  
  
-Note: The one-to-one relationship between `route_id` and `fare_id in` `fare_rules.txt` precludes 
+Note: The one-to-one relationship between `route_id` and `fare_id` in [`fare_rules.txt`](../fares_rules.md) precludes 
 the ability to represent fares that vary by time of day for the same route, 
 e.g. peak/off-peak. Our work around is to use `fare_id`, `start_time` and `end_time` in 
-`fare_rules_ft.txt` to return `fare_class`, which is then used in `fare_attributes_ft.txt` 
+[`fare_periods_ft.txt`](../fare_periods_ft.md) to return `fare_period`, which is then used in [`fare_attributes_ft.txt`](../fare_attributes_ft.md) 
 to return the correct fare. 
 
-Thus `fare_attributes_ft.txt` substitutes (rather than augments) for `fare_attributes.txt`.
+Thus [`fare_attributes_ft.txt`](../fare_attributes_ft.md) substitutes (rather than augments) for [`fare_attributes.txt`](../fare_attributes.md).
 
 File MUST contain the following attributes:
 
-Required Attributes	| Description										
-----------			| -------------		
-`fare_period`		| Contains an ID that uniquely identifies the fare period.  The `fare_period` is dataset unique.
-`price`				| Float fare price in the unit specified by `currency_type`
-`currency_type`		| Defines the currency used to pay the fare in [ISO 4217](http://en.wikipedia.org/wiki/ISO_4217) alphabetical currency codes
-`payment_method`	| When the fare must be paid:
--					| 0 - on board
--					| 1 - before boarding
-`transfers`			| Number of transfers permitted on this fare:
--					| 0 - none
--					| 1 - one
--					| 2 - two  
--				    | (empty): If this field is empty, unlimited transfers are permitted  
+| Required Attributes	| Description										
+| ----------			| -------------		
+| `fare_period`		| Contains an ID that uniquely identifies the fare period.  The `fare_period` is dataset unique.
+| `price`				| Float fare price in the unit specified by `currency_type`
+| `currency_type`		| Defines the currency used to pay the fare in [ISO 4217](http://en.wikipedia.org/wiki/ISO_4217) alphabetical currency codes
+| `payment_method`	| When the fare must be paid:
+|					| 0 - on board
+|					| 1 - before boarding
+|`transfers`			| Number of transfers permitted on this fare:
+|					| 0 - none
+|					| 1 - one
+|					| 2 - two  
+|	    | (empty): If this field is empty, unlimited transfers are permitted  
 
 File MAY contain the following attributes:
 

--- a/files/fare_periods_ft.md
+++ b/files/fare_periods_ft.md
@@ -15,7 +15,7 @@ File MUST contain the following attributes:
 
 Required Attributes	| Description										
 ----------			| -------------		
-`fare_id`			| An ID that links to `fare_id` in `fare_rules.txt`.  
+`fare_id`			| An ID that links to `fare_id` in [`fare_rules.txt`](../fare_rules.md).  
 `fare_period`		| Contains the name of the `fare_period` that links to the same attribute in [`fare_attributes_ft.txt`](fare_attributes_ft.md).
 `start_time`		| (HH:MM:SS from midnight or blank/`default` to indicate a default fare)  This is so we can model fares that fluctuate by time of day. If no time of day is specified, it is assumed that this is the base fare and that other time of days will override it.  
 `end_time`			| (HH:MM:SS from midnight or blank/`default` to indicate a default fare)  Time when the fare is no longer valid (i.e. if the fare ends at 11:59:59, then `end_time` would be 12:00) This is so we can model fares that fluctuate by time of day. If no time of day is specified, it is assumed that this is the base fare and that other time of days will override it.

--- a/files/fare_transfer_rules_ft.md
+++ b/files/fare_transfer_rules_ft.md
@@ -11,13 +11,13 @@ Examples of how to specify various fare schemes can be found in the [fares page]
 
 File MUST contain the following attributes:
 
-Required Attributes	| Description										
-----------			| -------------		
-`from_fare_period`	| An ID that identifies the `fare_period` that the passenger is coming from.  
-`to_fare_period`	| An ID that identifies the `fare_period' that the passenger is going to.  
-`transfer_fare_type` |   One of:
- - | `transfer_cost`:  assumes that the full value fare is not paid again  
- - | `transfer_discount`:   is a subtraction from the cumulative fare  
- - | `transfer_free`:  is a ridiculous way to say "free transfer"  
-`transfer_fare`		|  If `transfer_fare_type` `==` `transfer_free`, this column is ignored.  Otherwise, this must be a non-negative value in whatever the fare currency that is added to the initial fare in the case of a transfer cost or subtracted from the combined fare of the segments in the case of transfer discount.
+| Required Attributes	| Description										
+| ----------			| -------------		
+| `from_fare_period`	| An ID that identifies the `fare_period` that the passenger is coming from.  
+| `to_fare_period`	| An ID that identifies the `fare_period` that the passenger is going to.  
+| `transfer_fare_type` |   One of:
+| | `transfer_cost`:  assumes that the full value fare is not paid again  
+| | `transfer_discount`:   is a subtraction from the cumulative fare  
+| | `transfer_free`:  is a ridiculous way to say "free transfer"  
+|`transfer_fare`		|  If `transfer_fare_type` `==` `transfer_free`, this column is ignored.  Otherwise, this must be a non-negative value in whatever the fare currency that is added to the initial fare (in the case of a `transfer cost`) or subtracted from the combined fare of the segments (in the case of `transfer discount`).
 

--- a/files/stop_times.md
+++ b/files/stop_times.md
@@ -18,21 +18,21 @@ Required Attributes	| Description
 
 File MAY contain the following attributes:
 
-Optional Attributes		| Description										
-----------				| -------------		
-`stop_headsign`			| Text that appears on sign that identifies the trips destination to passengers.  use this field to override default headsign when it changes at stops.
-`pickup_type`			| Type of pickup:
-- 						| *0/default - regular pickup*
-- 						| *1 - no pickup available*
-- 						| *2 - must phone agency*
-- 						| *3 - must coordinate with driver*
-`drop_off_type`			| Type of drop off: 
-- 						| *0/default - regular drop off*
-- 						| *1 - no drop off available*
-- 						| *2 - must phone agency*
-- 						| *3 - must coordinate with driver*
-`shape_dist_traveled`	| Positions a stop as a distance from the first shape point in units that are used in this field in [`shapes.txt`](shapes.md)
-`timepoint`				|Indicates if specified arrival and departure times for a stop are strictly adhered to by the transit vehicle or if they are approximate and/or interpolated.  
--						| *empty - times considered exact*
-- 						| *0 - times considered approximate*
-- 						| *1 - times considered exact*
+| Optional Attributes		| Description										
+| ----------				| -------------		
+| `stop_headsign`			| Text that appears on sign that identifies the trips destination to passengers.  use this field to override default headsign when it changes at stops.
+| `pickup_type`			| Type of pickup:
+| 						| *0/default - regular pickup*
+| 						| *1 - no pickup available*
+| 						| *2 - must phone agency*
+| 						| *3 - must coordinate with driver*
+|`drop_off_type`			| Type of drop off: 
+| 						| *0/default - regular drop off*
+| 						| *1 - no drop off available*
+| 						| *2 - must phone agency*
+| 						| *3 - must coordinate with driver*
+|`shape_dist_traveled`	| Positions a stop as a distance from the first shape point in units that are used in this field in [`shapes.txt`](shapes.md)
+|`timepoint`				| Indicates if specified arrival and departure times for a stop are strictly adhered to by the transit vehicle or if they are approximate and/or interpolated.  
+|						| *empty - times considered exact*
+| 						| *0 - times considered approximate*
+| 						| *1 - times considered exact*

--- a/files/stops.md
+++ b/files/stops.md
@@ -17,22 +17,12 @@ Required Attributes	| Description
 
 File MAY contain the following attributes:
 
-Optional Attributes		| Description										
-----------				| -------------		
-`stop_code`				| Short text or a number that identifies the stop for passengers (i.e. EMB)
-`stop_desc`				| Description of stop or station
-`zone_id`				| Defines a fare zone for the stop ID. Required if you want to provide fare information in [`fare_rules.txt`](fare_rules.md) that uses zones.
-`location_type`			| Identifies whether this stop is a stop or station.  If nothing is specified or is blank, it is assumed it is a stop.  Stations can have different properties from stops.
-- 						| *0 or blank - stop*
-- 						| *1 - station (contains one or more stops)*
-`parent_station`		| For stops inside stations, identifies station associated with the stop.  `Stops.txt` must also contain a row where this stop id is assigned a location type 1.
-`stop_timezone`			| Contains timezone where stop or station is located.  If omitted, stop assumed to be located in timezone in [`agency.txt`](agency.md).
-`wheelchair_boarding`	| Identifies whether wheelchair boardings are possible from the specified stop or station. 
-- 						| *0 - no information*
-- 						| *1 - some vehicles can be boarded by wheelchair*
-- 						| *2 - wheelchair boarding not possible*
-- 						| If the stop is part of the station:
-- 						| *0 - will inherit from parent station, if specified.*
-- 						| *1 - there is an accessible path from outisde station to stop*
-- 						| *2 - no accessible path to specific stop*
-
+| Optional Attributes		| Description										
+| ----------				| -------------		
+| `stop_code`				| Short text or a number that identifies the stop for passengers (i.e. EMB)
+| `stop_desc`				| Description of stop or station
+| `zone_id`				| Defines a fare zone for the stop ID. Required if you want to provide fare information in [`fare_rules.txt`](fare_rules.md) that uses zones.
+| `location_type`			| Identifies whether this stop is a stop or station.  If nothing is specified or is blank, it is assumed it is a stop.  Stations can have different properties from stops. <br> *0 or blank - stop* <br> *1 - station (contains one or more stops)*
+| `parent_station`		| For stops inside stations, identifies station associated with the stop.  [`Stops.txt`](../stops.md) must also contain a row where this stop id is assigned a location type 1.
+| `stop_timezone`			| Contains timezone where stop or station is located.  If omitted, stop assumed to be located in timezone in [`agency.txt`](agency.md).
+| `wheelchair_boarding`	| Identifies whether wheelchair boardings are possible from the specified stop or station. <br> *0 - no information* <br> *1 - some vehicles can be boarded by wheelchair* <br> *2 - wheelchair boarding not possible* <br> <br> If the stop is part of the station: <br> *0 - will inherit from parent station, if specified.* <br> *1 - there is an accessible path from outisde station to stop* <br> *2 - no accessible path to specific stop*

--- a/files/stops_ft.md
+++ b/files/stops_ft.md
@@ -14,25 +14,15 @@ Required Attributes	| Description
 
 File MAY contain the following attributes:
 
-Optional Attributes		| Description										
-----------				| -------------		
-`shelter`			| String describing the shelter facility at the station. Valid entries include: 
-- 						| *blank - no information*
-- 						| *inside*
-- 						| *sheltered*
-- 						| *inside*
-- 						| *none*
+| Optional Attributes		| Description										
+| ----------				| -------------		
+| `shelter`			| String describing the shelter facility at the station. Valid entries include: 
+| 						| *blank - no information* <br> *inside* <br> *sheltered* <br> *inside* <br> *none*
 `lighting`			| Boolean indicating presence of lighting.
 `bike_parking`		| String describing bike parking facilities at station. Valid entires include:
-- 						| *blank - no information*
-- 						| *none*
-- 						| *standard_outside*
-- 						| *standard_inside*
-- 						| *lockers*
-- 						| *valet*
-`bike_share_station`	| Boolean indicating presence of a bike share station.
-`seating`				| Boolean. Indicates the presence of seating at the station. Stop-level overrides station-level.
-`platform_height`		| Float-point number in inches. Used with vehicle height to determine level boarding.
-`level`				| Integer, floors from street level.  Indicates how far up or below street level the stop is relative to the station and the station relative to the street level.
-`off_board_payment`	| Boolean indicating if there are fare gates or tagging stations before the platform.  Can be overriden by [`stop_times_ft`](stop_times_ft.md) value for a specific service.
-
+| 						| *blank - no information* <br> *none* <br> *standard_outside* <br> *standard_inside* <br> *lockers* <br> *valet*
+| `bike_share_station`	| Boolean indicating presence of a bike share station.
+| `seating`				| Boolean. Indicates the presence of seating at the station. Stop-level overrides station-level.
+| `platform_height`		| Float-point number in inches. Used with vehicle height to determine level boarding.
+| `level`				| Integer, floors from street level.  Indicates how far up or below street level the stop is relative to the station and the station relative to the street level.
+| `off_board_payment`	| Boolean indicating if there are fare gates or tagging stations before the platform.  Can be overriden by [`stop_times_ft.txt`](stop_times_ft.md) value for a specific service.

--- a/files/stops_ft.md
+++ b/files/stops_ft.md
@@ -16,11 +16,9 @@ File MAY contain the following attributes:
 
 | Optional Attributes		| Description										
 | ----------				| -------------		
-| `shelter`			| String describing the shelter facility at the station. Valid entries include: 
-| 						| *blank - no information* <br> *inside* <br> *sheltered* <br> *inside* <br> *none*
+| `shelter`			| String describing the shelter facility at the station. Valid entries include: <br> *blank - no information* <br> *inside* <br> *sheltered* <br> *inside* <br> *none*
 `lighting`			| Boolean indicating presence of lighting.
-`bike_parking`		| String describing bike parking facilities at station. Valid entires include:
-| 						| *blank - no information* <br> *none* <br> *standard_outside* <br> *standard_inside* <br> *lockers* <br> *valet*
+`bike_parking`		| String describing bike parking facilities at station. Valid entires include: <br> *blank - no information* <br> *none* <br> *standard_outside* <br> *standard_inside* <br> *lockers* <br> *valet*
 | `bike_share_station`	| Boolean indicating presence of a bike share station.
 | `seating`				| Boolean. Indicates the presence of seating at the station. Stop-level overrides station-level.
 | `platform_height`		| Float-point number in inches. Used with vehicle height to determine level boarding.

--- a/files/trips.md
+++ b/files/trips.md
@@ -22,15 +22,6 @@ Optional Attributes		| Description
 `trip_short_name`		| Text that appears in schedules and sign boards.
 `block_id`				| Two or more sequential trips made using same vehicle where passenger can transfer by staying on same vehicle. `block_id` must be referenced by two or more trips in trips.txt.
 `shape_id`				| Defines shape for the trip from [`shapes.txt`](shapes.md) file.
-`wheelchair_accessible`	| Is this transit vehicle trip wheelchair accessible: 
-				    -	|	  *0 - no accessibility info*
-					-	|	  *1 - vehicle on this trip can accommodate at least one rider in a wheelchair*
-					-	|	  *2 - no riders in wheelchairs can be accommodated on this trip* 
-`bikes_allowed`			| Does this transit vehicle trip bike allow bikes:
-				    -	|	  *0 - no bike accessibility info*
-				    -	|	  *1 - vehicle on this trip can accommodate at least one bicycle*		
-				    -	|	  *2 - no bicycles can be accommodated on this trip*		    
-`direction_id`			| ID that contains a binary value that indicates the direction of the trip:
-				    -	|	  *0 - travel in one direction*
-				    -	|	  *1 - travel in opposite direction*	
-
+`wheelchair_accessible`	| Is this transit vehicle trip wheelchair accessible: <br> *0 - no accessibility info* <br> *1 - vehicle on this trip can accommodate at least one rider in a wheelchair* <br> *2 - no riders in wheelchairs can be accommodated on this trip*
+`bikes_allowed`			| Does this transit vehicle trip bike allow bikes: <br> *0 - no bike accessibility info* <br> *1 - vehicle on this trip can accommodate at least one bicycle* <br> *2 - no bicycles can be accommodated on this trip*		    
+`direction_id`			| ID that contains a binary value that indicates the direction of the trip: <br> *0 - travel in one direction* <br>*1 - travel in opposite direction*	


### PR DESCRIPTION
In the table of optional files, the link labeled "fare_rules_ft.txt" is 404.  File has been renamed in the standard to fare_periods_ft, so change it here as well, right?