### PR TITLE
Update stops_ft.md

### DIFF
--- a/files/stops_ft.md
+++ b/files/stops_ft.md
@@ -20,7 +20,6 @@ Optional Attributes		| Description
 `-` | `blank` - no information
 `-` | `inside`
 `-` | `sheltered`
-`-` | `inside`
 `-` | `none`
 `lighting`			  | Boolean indicating presence of lighting.
 `bike_parking`		| String describing bike parking facilities at station. Valid entires include:


### PR DESCRIPTION
@e-lo , @lmz , @sdrewc , @stefancoe 

First field under Optional Attributes, "shelter", contains "inside" twice under list of valid entries.  Deleting one makes it match the Final Task 2 Tech memo documentation table in Appendix B, page 58.  But not sure whether this is an extra field or the 2nd "inside" really should be something else, and the Tech Memo is the one out of date.  Thx.  

