### PR TITLE
Clean-up markdown for proper table display

### DIFF
--- a/files/transfers.md
+++ b/files/transfers.md
@@ -10,14 +10,14 @@ Filename: `transfers.txt`
  
 File MUST contain the following attributes:
  
-Required Attributes	| Description										
-----------			| -------------		
-`from_stop_id`		| From `stop_id` or park and ride / kiss and ride node.  Cannot be the same as `to_stop_id`.
-`to_stop_id`		| To `stop_id` or park and ride / kiss and ride node. Cannot be the same as `from_stop_id`.
-`transfer_type`		| Type of transfer:
--					| 0 / Empty - a recommended transfer point
--					| 1 - timed transfer between two routes
--					| 2 - requires a minimum amount of time, specified by `min_transfer_time`
--					| 3 - transfers not possible between routes
-`min_transfer_time`	| When a connection between routes requires an amount of time between arrival and departure (`transfer_type`=2), this field defines the amount of time that must be available for a typical rider - in seconds.
+| Required Attributes	| Description |
+|----------			    | -------------		                                                                         |
+|`from_stop_id`		    | From `stop_id` or park and ride / kiss and ride node.  Cannot be the same as `to_stop_id`. |
+|`to_stop_id`		    | To `stop_id` or park and ride / kiss and ride node. Cannot be the same as `from_stop_id`.  |
+|`transfer_type`        | Type of transfer:                                                                          |
+|	&nbsp;				| 0 / Empty - a recommended transfer point                                                   | 
+|	&nbsp;				| 1 - timed transfer between two routes                                                      |
+|	&nbsp;				| 2 - requires a minimum amount of time, specified by `min_transfer_time`                    |
+|	&nbsp;				| 3 - transfers not possible between routes                                                  |
+|`min_transfer_time`	| When a connection between routes requires an amount of time between arrival and departure (`transfer_type`=2), this field defines the amount of time that must be available for a typical rider - in seconds. |
 


### PR DESCRIPTION
The dash (-) is giving the markdown stylesheet a problem. I didn't realize min_transfer_time was a required field with the prior formatting. This fixes the markdown to make the table work, and makes the final row more clearly visible.