### PR TITLE
Add file & note to README; add new var to agency.txt; misc text cleanup throughout

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,12 +74,14 @@ Filename 					| Description
 [`shapes.txt`](/files/shapes.md)								 	| transit route shape points  
 [`stops_ft.txt`](/files/stops_ft.md)						    	| additional transit stop and station information	
 [`stop_times_ft.txt`](/files/stop_times_ft.md)	                    | additional transit trip stop time information	 
-[`fare_attributes.txt`](/files/fare_attributes.md)			| basic fare attributes  
-[`fare_attributes_ft.txt`](/files/fare_attributes_ft.md)			| additional fare attributes  
+[`fare_attributes.txt`](/files/fare_attributes.md)			| fare attributes (see note below)
+[`fare_attributes_ft.txt`](/files/fare_attributes_ft.md)			| fare attributes  (see note below)
 [`fare_rules.txt`](/files/fare_rules.md)							| fare rules  
 [`fare_periods_ft.txt`](/files/fare_periods_ft.md)						| additional fare rules  
 [`fare_transfer_rules_ft.txt`](/files/fare_transfer_rules_ft.md)	| fare transfer rules  
 [`zones_ft.txt`](/files/zones_ft.md)	                            | zone locations 
+
+*Note: `fare_attributes_ft.txt` is an extended version of the optional GTFS file `fare_attributes.txt` that allows for representation of time-of-day pricing (e.g., peak surcharges).  Both files are documented here in this repository for completeness, but only one of the two is needed for a given implementation of GTFS-PLUS.*
 
 # Fares
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ A GTFS-PLUS transit network MAY include the following files:
 Filename 					| Description										
 ----------					| -------------		
 [`drive_access_ft.txt`](/files/drive_access_ft.md)					| drive access links  
-[`bike_access_ft.txt`](/files/bike_access_ft.md)					| walk access links  
+[`bike_access_ft.txt`](/files/bike_access_ft.md)					| bike access links  
 [`drive_access_points_ft.txt`](/files/drive_access_points_ft.md) 	| park and ride access links; must be included if provide drive access links.  
 [`shapes.txt`](/files/shapes.md)								 	| transit route shape points  
 [`stops_ft.txt`](/files/stops_ft.md)						    	| additional transit stop and station information	

--- a/README.md
+++ b/README.md
@@ -74,7 +74,8 @@ Filename 					| Description
 [`shapes.txt`](/files/shapes.md)								 	| transit route shape points  
 [`stops_ft.txt`](/files/stops_ft.md)						    	| additional transit stop and station information	
 [`stop_times_ft.txt`](/files/stop_times_ft.md)	                    | additional transit trip stop time information	 
-[`fare_attributes_ft.txt`](/files/fare_attributes_ft.md)			| fare attributes  
+[`fare_attributes.txt`](/files/fare_attributes.md)			| basic fare attributes  
+[`fare_attributes_ft.txt`](/files/fare_attributes_ft.md)			| additional fare attributes  
 [`fare_rules.txt`](/files/fare_rules.md)							| fare rules  
 [`fare_periods_ft.txt`](/files/fare_periods_ft.md)						| additional fare rules  
 [`fare_transfer_rules_ft.txt`](/files/fare_transfer_rules_ft.md)	| fare transfer rules  

--- a/fares.md
+++ b/fares.md
@@ -4,11 +4,11 @@ Fares can be quite complex.  This page illustrates examples of how to specify th
 ### Single leg, no transfer, flat fare
 
 The example below illustrates how the fare for a single leg transit trip using a service 
-that has flat fare system. First [`fare_rules.txt`](../fare_rules.md) is queried on `route_id`, `origin_zone` & 
-`destination_zone` to return it’s `fare_id`.  In this case, origin and destination zones have a value of None, 
+that has flat fare system. First [`fare_rules.txt`](/files/fare_rules.md) is queried on `route_id`, `origin_id` & 
+`destination_id` to return it’s `fare_id`.  In this case, the origin and destination zones have a value of None, 
 which represents cases where stops are never used in a zonal fee 
-structure. Then, [`fare_periods_ft.txt`](../fare_periods_ft.md) is queried on `fare_id` and the time of departure (>= to 
-`start_time`, <= `end_time`) to return `fare_period`. Finally, [`fare_attributes_ft.txt`](../fare_attributes_ft.md) is queried 
+structure. Then, [`fare_periods_ft.txt`](/files/fare_periods_ft.md) is queried on `fare_id` and the time of departure (>= to 
+`start_time`, <= `end_time`) to return `fare_period`. Finally, [`fare_attributes_ft.txt`](/files/fare_attributes_ft.md) is queried 
 on `fare_period`, and the cost of the fare is returned by the `price` field. 
 
 *[`stops.txt`](/files/stops.md)*
@@ -40,34 +40,34 @@ muni-allday		| 2.50 		| USD 				| -				| 5400
 
 To capture the cost of this scenario, the cost of each leg is calculated using the same 
 method proposed for a single leg trip. We then use the *from* `fare_period` and the *to* 
-`fare_period` to get the `transfer_fare_type`, which has three possible values: `transfer_cost`, `transfer_discount`, or `transfer_free`. The transfer is free if the value of this field is `transfer_free`. If `transfer_discount`, the amount in the `transfer_fare` field is subtracted from the the full cost of the fare of the to leg. If `transfer_cost`, the full amount of the `transfer_fare` field is the cost of the transfer.
+`fare_period` to get the `transfer_fare_type`, which has three possible values: `transfer_cost`, `transfer_discount`, or `transfer_free`. The transfer is free if the value of this field is `transfer_free`. If `transfer_discount`, the amount in the `transfer_fare` field is subtracted from the the full cost of the fare of the *to* leg. If `transfer_cost`, the full amount of the `transfer_fare` field is the cost of the transfer.
 
 ### Multiple Transfers
 A second transfer would work in a similar fashion, however, it is possible (unlikely ?) that the fare would have to be calculated using the *from* `fare_period` for both the first and second leg to determine which `transfer_rule` to use. For example, a rider uses the same `fare_period` in the first and third leg of a three leg trip. This `fare_period` is entitled to a free transfer (`transfer_fare_type` = `transfer_free`) when staying with the same fare_period during a transfer (e.g. a metro bus to metro bus transfer). Assuming the transfer has not expired (and this scenario is permitted), the rider is eligible for a free transfer based on the `fare_period` associated with the first leg of the trip, even if there is a transfer cost associated with the second and third leg.  
 
 ### Systemwide Fare
 The following two-leg (one transfer) trip demonstrates how a system-wide fare would be 
-calculated using Pierce Transit as an example. First, [`fare_rules.txt`](../fare_rules.md) is queried on the 
-`route_id`, `origin_zone` and `destination_zone` of the first leg to return its `fare_id`.  In 
+calculated using Pierce Transit as an example. First, [`fare_rules.txt`](/files/fare_rules.md) is queried on the 
+`route_id`, `origin_id` and `destination_id` of the first leg to return its `fare_id`.  In 
 this case, the origin and destination have zones but are the same because these stops need 
-zones for Sound Transit, our regional express bus service. Then [`fare_periods_ft.txt`](../fare_periods_ft.md) is 
+zones for Sound Transit, our regional express bus service. Then [`fare_periods_ft.txt`](/files/fare_periods_ft.md) is 
 queried on `fare_id` and the time of departure (>= to `start_time`, <= `end_time`) to return 
-`fare_period`. Next, [`fare_attributes_ft.txt`](../fare_attributes_ft.md) is queried on `fare_period`, and the cost of the fare 
+`fare_period`. Next, [`fare_attributes_ft.txt`](/files/fare_attributes_ft.md) is queried on `fare_period`, and the cost of the fare 
 is returned by the `price` field. 
 
 The next step is to determine the transfer rule for this particular transfer. We use the 
 `route_id` of the second leg to get the `fare_id` which, along with departure time, is used 
-to get `fare_period` from [`fare_periods_ft.txt`](../fare_periods_ft.md). The `from_fare_period`  and the `to_fare_period` are used 
-to get `tranfer_fare_type` and `transfer_far` from [`fare_transfer_rules_ft.txt`](../fare_transfer_rules_ft.md). In this case `transfer_fare_type` is `transfer_free` indicating that there is no fee for the second leg of this trip. 
+to get `fare_period` from [`fare_periods_ft.txt`](/files/fare_periods_ft.md). The `from_fare_period`  and the `to_fare_period` are used 
+to get `tranfer_fare_type` and `transfer_far` from [`fare_transfer_rules_ft.txt`](/files/fare_transfer_rules_ft.md). In this case `transfer_fare_type` is `transfer_free` indicating that there is no fee for the second leg of this trip. 
 
 **First Leg:**
 
-*[`stops.txt`](/`file`s/stops.md)*
+*[`stops.txt`](/files/stops.md)*
 
 `stop_id` 	| `stop_name` 				| `zone_id`	| ...										
 --------- 	| -----	 					| -----	   	| -----	
-1 			| Pacific Ave/166th St. 	| Tacoma	| ...
-2 			| Pacific Ave/112th St. 	| Seattle	| ...
+1 			| Pacific Ave/166th St. 	| Pierce	| ...
+2 			| Pacific Ave/112th St. 	| Pierce	| ...
 
 *[`routes_ft.txt`](/files/routes_ft.md)*
 
@@ -81,7 +81,7 @@ PT01  		| `local_bus` | 1
 --------- 		| -----	 		| -----	   		| -----
 Pierce-Local	| PT01			| Pierce		| Pierce
 
-*[`fare_rules_ft.txt`](/files/fare_rules_ft.md)*
+*[`fare_periods_ft.txt`](/files/fare_periods_ft.md)*
 
 `fare_id` 		| `fare_period` 		| `start_time`	| `end_time`											
 --------- 		| -----	 			| -----	  		| ---- 		
@@ -114,7 +114,7 @@ PT53  		| local_bus 	| 1
 --------- 		| -----	 		| -----	   		
 Pierce-Local	| `PT53`		| ...
 
-*[`fare_rules_ft.txt`](/files/fare_rules_ft.md)*
+*[`fare_periods_ft.txt`](/files/fare_periods_ft.md)*
 
 `fare_id` 		| `fare_period` 		| `start_time`	| `end_time`											
 --------- 		| -----	 			| -----	  		| ---- 		
@@ -133,32 +133,32 @@ Pierce-AllDay	| 2.00 		| USD 				| -				| 1
 Pierce-AllDay		| Pierce-AllDay 	| `transfer_free`			| 0	
 
 ### Inter-Agency Fare, zonal fee structure
-The following illustrates how an inter-agency fare (one transfer, two different fare classes) would be calculated. First, [`fare_rules.txt`](../fare_rules.md) is queried on the `route_id`, `origin_zone` and `destination zone` of the first leg to return its `fare_id`. Then [`fare_periods_ft.txt`](../fare_periods_ft.md) is queried on `fare_id` and the time of departure (>= to `start_time`, <= `end_time`) to return `fare_period`. Next, [`fare_attributes_ft.txt`](../fare_attributes_ft.md) is queried on `fare_period`, and the cost of the fare is returned by the `price` field.
+The following illustrates how an inter-agency fare (one transfer, two different fare classes) would be calculated. First, [`fare_rules.txt`](/files/fare_rules.md) is queried on the `route_id`, `origin_id` and `destination_id` of the first leg to return its `fare_id`. Then [`fare_periods_ft.txt`](/files/fare_periods_ft.md) is queried on `fare_id` and the time of departure (>= to `start_time`, <= `end_time`) to return `fare_period`. Next, [`fare_attributes_ft.txt`](/files/fare_attributes_ft.md) is queried on `fare_period`, and the cost of the fare is returned by the `price` field.
 
-The next step is to determine the transfer rule for this particular transfer. We use the `route_id` of the second leg to get the `fare_id` which can then be used to get `fare_period`. We then get the rule that applies to this transfer, which is returned by querying [`fare_transfer_rules_ft.txt`](../fare_transfer_rules_ft.md) on `from_fare_period` and `to_fare_period`. In this case, the field `transfer_fare_type` in the returned record is `transfer_cost`, indicating the amount in the `transfer_fare` field is the cost of the transfer.
+The next step is to determine the transfer rule for this particular transfer. We use the `route_id` of the second leg to get the `fare_id` which can then be used to get `fare_period`. We then get the rule that applies to this transfer, which is returned by querying [`fare_transfer_rules_ft.txt`](/files/fare_transfer_rules_ft.md) on `from_fare_period` and `to_fare_period`. In this case, the field `transfer_fare_type` in the returned record is `transfer_cost`, indicating the amount in the `transfer_fare` field is the cost of the transfer.
 
 **First Leg:**
 
-*[`stops.txt`](../stops.md)* 
+*[`stops.txt`](/files/stops.md)* 
 
 `stop_id` | `stop_name` | `zone_id` | ...
 ----- | -----	| -----	| -----	
 1 | TACOMA_DOME | Tacoma | ...
 2 | 4th Ave & Cherry | Seattle | ...
 
-*[`fare_rules.txt`](../fare_rules.md)*
+*[`fare_rules.txt`](/files/fare_rules.md)*
 
 `fare_id` | `origin_id` | `contains_id`
 ----- 	| -----	| -----	
 ST_EXPRESS  | Tacoma | 0
 
-*[`fare_periods_ft.txt`](../fare_periods_ft.md)*
+*[`fare_periods_ft.txt`](/files/fare_periods_ft.md)*
 
 `fare_id` | `fare_period` | `start_time` | `end_time` 
 ----- | -----	| -----	| -----	
 ST_EXPRESS | ST_EXPRESS_2Z | 00:00:00 | 24:00:00
 
-*[`fare_attributes_ft.txt`](../fare_attributes_ft.md)* 
+*[`fare_attributes_ft.txt`](/files/fare_attributes_ft.md)* 
 
 `fare_period` | `price` | `currency_type` | `payment_method` | `transfers`
 ----- | -----	| -----	| -----	| -----	
@@ -166,36 +166,36 @@ ST_EXPRESS_2Z | 3.40 | USD | 1 | 2
 
 **Second leg:**
 
-*[`stops.txt`](../stops.md)*
+*[`stops.txt`](/files/stops.md)*
 
 `stop_id` | `stop_name` | `zone_id` | ...
 ----- | -----	| -----	| -----	
 3 | James St. & 3rd Ave. | Seattle | ...
 4 | E Jefferson St & 17th Ave | Seattle | ...
 
-*[`fare_rules.txt`](../fare_rules.md)* 
+*[`fare_rules.txt`](/files/fare_rules.md)* 
 
 `fare_id` | `origin_id` | `destination_id`
 ----- 	| -----	| -----	
 Metro_1Z | Seattle | Seattle
 
-*[`fare_periods_ft.txt`](../fare_periods_ft.md)*
+*[`fare_periods_ft.txt`](/files/fare_periods_ft.md)*
 
 `fare_id` | `fare_period` | `start_time` | `end_time`
 ----- | -----	| -----	| -----	
 Metro_1Z | METRO_1Z_P | 06:00:00 | 09:00:00
 
-*[`fare_attributes_ft.txt`](../fare_attributes_ft.md)*
+*[`fare_attributes_ft.txt`](/files/fare_attributes_ft.md)*
 
 `fare_period` | `price` | `currency_type` | `payment_method` | `transfers`
 ----- | -----	| -----	| -----	| -----	
 Metro_1Z_P | 2.75 | USD | 1 | -
 
-*[`fare_transfer_rules_ft.txt`](../fare_transfer_rules_ft.md)*
+*[`fare_transfer_rules_ft.txt`](/files/fare_transfer_rules_ft.md)*
 
 `from_fare_period` | `to_fare_period` | `transfer_fare_type` | `transfer_fare`
 ----- | -----	| -----	| -----	
-ST_EXPRESS_2Z | Metro_1Z_P | False | 1
+ST_EXPRESS_2Z | Metro_1Z_P | transfer_cost | 1
 
 ### Zone-Based Fares
 Commuter rail frequently calculates fares based on the number of zones you traverse.  This 
@@ -214,7 +214,7 @@ can be specified as follows.
 ------ 		| -----	 		| -----	   		
 SOUNDER-2Z	| Seattle		| Everett
 
-*[`fare_rules_ft.txt`](/files/fare_rules_ft.md)*
+*[`fare_periods_ft.txt`](/files/fare_rules_ft.md)*
 
 `fare_id` 	| `fare_period` 		| `start_time`	| `end_time`											
 --------- 	| -----	 			| -----	  		| ---- 		

--- a/files/agency.md
+++ b/files/agency.md
@@ -20,7 +20,7 @@ File MAY contain the following attributes:
 
 Optional Attributes	| Description										
 ----------			| -------------		
-`agency_lang`		| String. Two-letter, ISO 639-1 code for primary language used by agency.  Case-insensitive (both EN and en are accepted)
+`agency_lang`		| String. Two-letter, [ISO 639-1 code](http://www.loc.gov/standards/iso639-2/php/code_list.php) for primary language used by agency.  Case-insensitive (both EN and en are accepted)
 `agency_phone`		| String. Phone number for agency.
 `agency_fare_url`	| String. URL of where fares are defined.
 

--- a/files/agency.md
+++ b/files/agency.md
@@ -23,4 +23,5 @@ Optional Attributes	| Description
 `agency_lang`		| String. Two-letter, [ISO 639-1 code](http://www.loc.gov/standards/iso639-2/php/code_list.php) for primary language used by agency.  Case-insensitive (both EN and en are accepted)
 `agency_phone`		| String. Phone number for agency.
 `agency_fare_url`	| String. URL of where fares are defined.
+`agency_email`	| String. Contains a single valid email address actively monitored by the agency’s customer service department.
 

--- a/files/bike_access_ft.md
+++ b/files/bike_access_ft.md
@@ -26,7 +26,7 @@ Optional Attributes	| Description
 `cycletrack_dist`	| Float, distance in miles that is an on-street separated cycletrack.
 `bike_lane_dist`	| Float, distance in miles that is in a bike lane.
 `bike_route_dist`	| Float, distance in miles that is a signed bike route.
-`num_left_turns`	| Int, number of left turns.
-`num_right_turns`	| Int, number of right turns.
-`num_thru`			| Int, number of intersections that are thru.
-`num_signals`		| Int, number of traffic signals along route.
+`num_left_turns`	| Integer, number of left turns.
+`num_right_turns`	| Integer, number of right turns.
+`num_thru`			| Integer, number of intersections that are thru.
+`num_signals`		| Integer, number of traffic signals along route.

--- a/files/drive_access_ft.md
+++ b/files/drive_access_ft.md
@@ -16,9 +16,9 @@ Required Attributes	| Description
 `direction`			| String that can have following values:
 `-`				  	  |    Access
 `-`	    		    |    Egress
-`dist`				  | Drive distance in miles between TAZ and lot.
-`cost`				  | Float cost in the unit specified by `currency_type` variable in [`fare_attributes_ft.txt`](/files/fare_attributes_ft.md)
-`travel_time`		| Float driving time in minutes between TAZ and lot.
+`dist`				  | Float. Drive distance in miles between TAZ and lot.
+`cost`				  | Float. Cost in the unit specified by `currency_type` variable in [`fare_attributes_ft.txt`](/files/fare_attributes_ft.md)
+`travel_time`		| Float. Driving time in minutes between TAZ and lot.
 `start_time`		| HH:MM:SS from midnight.  If blank, it is assumed that this is the base condition and other time of days will override it.
 `end_time`			| HH:MM:SS from midnight.  Time when drive access link is no longer valid (i.e. if it ends at 11:59:59, then `end_time` would be 12:00:00) If blank, it is assumed that this is the base condition and other time of days will override it.
 

--- a/files/drive_access_points_ft.md
+++ b/files/drive_access_points_ft.md
@@ -27,8 +27,8 @@ Optional Attributes	| Description
 `name`				| String name of the lot.
 `drop_off`			| Boolean, if not specified assumed to be true to indicated that drop-off/pick-ups are allowed.
 `capacity`			| Integer.  Represents number of parking spaces at park and ride.  If not specified, assumed to be zero and no parking is allowed.
-`hourly_cost`		| Hourly cost to park in the unit specified by `currency_type` variable in [`fare_attributes_ft.txt`](/files/fare_attributes_ft.md)
-`max_cost`			| Maximum daily cost to park  in the unit specified by `currency_type` variable in [`fare_attributes_ft.txt`](/files/fare_attributes_ft.md)
+`hourly_cost`		| Float. Hourly cost to park in the unit specified by `currency_type` variable in [`fare_attributes_ft.txt`](/files/fare_attributes_ft.md)
+`max_cost`			| Float. Maximum daily cost to park  in the unit specified by `currency_type` variable in [`fare_attributes_ft.txt`](/files/fare_attributes_ft.md)
 `type`				| String, with possible values of: 
 -					|    surface
 -					|    underground

--- a/files/fare_attributes.md
+++ b/files/fare_attributes.md
@@ -13,16 +13,16 @@ File MUST contain the following attributes:
 Required Attributes	| Description										
 ----------			| -------------		
 `fare_id`			| Contains an ID that uniquely identifies the fare class.  The `fare_id` is dataset unique.
-`price`				| Float fare price in the unit specified by `currency_type`
-`currency_type`		| Defines the currency used to pay the fare in [ISO 4217](http://en.wikipedia.org/wiki/ISO_4217) alphabetical currency codes
+`price`				| Float. Fare price in the unit specified by `currency_type`
+`currency_type`		| String. Defines the currency used to pay the fare in [ISO 4217](https://en.wikipedia.org/wiki/ISO_4217) alphabetical currency codes
 `payment_method`	| When the fare must be paid:
--					| 0 - on board
--					| 1 - before boarding
+|					| 0 - on board
+|					| 1 - before boarding
 `transfers`			| Number of transfers permitted on this fare:
--					| 0 - none
--					| 1 - one
--					| 2 - two  
--				    | (empty): If this field is empty, unlimited transfers are permitted   
+|					| 0 - none
+|					| 1 - one
+|					| 2 - two  
+|				    | (empty): If this field is empty, unlimited transfers are permitted   
 
 File MAY contain the following attributes:
 

--- a/files/fare_rules.md
+++ b/files/fare_rules.md
@@ -20,13 +20,13 @@ File MUST contain the following attributes:
 
 Required Attributes	| Description										
 ----------			| -------------		
-`fare_id`			| Unique identifier to fare class in fare attributes file
+`fare_id`			| Unique identifier to match to `fare id` in fare attributes file
 
 File MAY contain the following attributes:
 
 Optional Attributes	| Description										
 ----------			| -------------		
-`route_id`			| Associates a fare ID with a route ID from the routes file.  If multiple route have the same attributes, create a row for each route.
-`origin_id`			| Origin fare zone ID, referenced from the stops file.  If several origin IDs have the same fare attributes, create a row for each origin ID.
-`destination_id`	| Destination fare zone ID, referenced from the stops file.  If several fare destination IDs have the same fare attributes, create a row for each destination ID.
-`contains_id`		| Associates a fare ID with a zone ID from the stops file and is associated with itineraries that pass through the `contains_id` zone.
+`route_id`			| Associates a fare ID with a route ID from [`routes.txt`](routes.md).  If multiple route have the same attributes, create a row for each route.
+`origin_id`			| Origin fare zone ID, referenced from [`stops.txt`](stops.md).  If several origin IDs have the same fare attributes, create a row for each origin ID.
+`destination_id`	| Destination fare zone ID, referenced from [`stops.txt`](stops.md).  If several fare destination IDs have the same fare attributes, create a row for each destination ID.
+`contains_id`		| Associates a fare ID with a zone ID from [`stops.txt`](stops.md) and is associated with itineraries that pass through the `contains_id` zone.

--- a/files/fare_rules.md
+++ b/files/fare_rules.md
@@ -29,4 +29,4 @@ Optional Attributes	| Description
 `route_id`			| Associates a fare ID with a route ID from the routes file.  If multiple route have the same attributes, create a row for each route.
 `origin_id`			| Origin fare zone ID, referenced from the stops file.  If several origin IDs have the same fare attributes, create a row for each origin ID.
 `destination_id`	| Destination fare zone ID, referenced from the stops file.  If several fare destination IDs have the same fare attributes, create a row for each destination ID.
-`contains_id`		| Associates a fare iD with a zone ID from the stops file and is associated with itineraries that pass through the `contains_id` zone.
+`contains_id`		| Associates a fare ID with a zone ID from the stops file and is associated with itineraries that pass through the `contains_id` zone.

--- a/files/stop_times.md
+++ b/files/stop_times.md
@@ -11,8 +11,8 @@ File MUST contain the following attributes:
 Required Attributes	| Description										
 ----------			| -------------		
 `trip_id`			| ID that uniquely identifies trip
-`arrival_time`		| Arrival time at a specific stop for a specific trip on a route in HH:MM:SS format measured from midnight.  For trips that span multiple dates, the time should be entered as a value greater than 2400000
-`departure_time`	| Departure time at a specific stop for a specific trip on a route in HH:MM:SS format measured from midnight.  For trips that span multiple dates, the time should be entered as a value greater than 2400000
+`arrival_time`		| Arrival time at a specific stop for a specific trip on a route in HH:MM:SS format measured from midnight.  For trips that span multiple dates, the time should be entered as a value greater than 240000
+`departure_time`	| Departure time at a specific stop for a specific trip on a route in HH:MM:SS format measured from midnight.  For trips that span multiple dates, the time should be entered as a value greater than 240000
 `stop_id`			| ID that uniquely identifies a stop
 `stop_sequence`		| Sequence number on a specific stop within a trip.  The first stop sequence is 1 and subsequent stops in the trip are sequentially numbered.
 
@@ -20,7 +20,7 @@ File MAY contain the following attributes:
 
 | Optional Attributes		| Description										
 | ----------				| -------------		
-| `stop_headsign`			| Text that appears on sign that identifies the trips destination to passengers.  use this field to override default headsign when it changes at stops.
+| `stop_headsign`			| Text that appears on sign that identifies the trips destination to passengers.  Use this field to override default headsign when it changes at stops.
 | `pickup_type`			| Type of pickup:
 | 						| *0/default - regular pickup*
 | 						| *1 - no pickup available*

--- a/files/stop_times_ft.md
+++ b/files/stop_times_ft.md
@@ -22,4 +22,4 @@ Optional Attributes		| Description
 `front_board_only`		| Boolean indicating the boarding can only be made through the front doors. 
 `reliability`			| Not yet defined.
 `level_boarding`		| Boolean indicating the level_boarding field indicates if the platform and the bus are level. Overrides logic from platform height.
-`percent_using_farebox` | Floating point value between 0 and 1 indicating the percent of passengers boarding who pay a cash fare at the farebox (as opposed to paying via Smart Card or other payment method). This value will be override `percent_using_farebox` in `routes_ft.txt`(routes_ft.md).  This is a TCQSM parameter used to calculate dwell time.
+`percent_using_farebox` | Floating point value between 0 and 1 indicating the percent of passengers boarding who pay a cash fare at the farebox (as opposed to paying via Smart Card or other payment method). This value will be override `percent_using_farebox` in [`routes_ft.txt`](routes_ft.md).  This is a TCQSM parameter used to calculate dwell time.

--- a/files/stop_times_ft.md
+++ b/files/stop_times_ft.md
@@ -22,4 +22,4 @@ Optional Attributes		| Description
 `front_board_only`		| Boolean indicating the boarding can only be made through the front doors. 
 `reliability`			| Not yet defined.
 `level_boarding`		| Boolean indicating the level_boarding field indicates if the platform and the bus are level. Overrides logic from platform height.
-`percent_using_farebox` | Floating point value between 0 and 1 indicating the percent of passengers boarding who pay a cash fare at the farebox (as opposed to paying via Smart Card or other payment method. This value will be override `percent_using_farebox` in `routes_ft`.  This is a TCQSM parameter used to calculate dwell time.
+`percent_using_farebox` | Floating point value between 0 and 1 indicating the percent of passengers boarding who pay a cash fare at the farebox (as opposed to paying via Smart Card or other payment method). This value will be override `percent_using_farebox` in `routes_ft.txt`(routes_ft.md).  This is a TCQSM parameter used to calculate dwell time.

--- a/files/stops_ft.md
+++ b/files/stops_ft.md
@@ -33,6 +33,6 @@ Optional Attributes		| Description
 `seating`			      	 | Boolean. Indicates the presence of seating at the station. Stop-level overrides station-level.
 `platform_height`		   | Float-point number in inches. Used with vehicle height to determine level boarding.
 `level`				         | Integer, floors from street level.  Indicates how far up or below street level the stop is relative to the station and the station relative to the street level.
-`off_board_payment`	   | Boolean indicating if there are fare gates or tagging stations before the platform.  Can be overriden by [`stop_times_ft`](stop_times_ft.md) value for a specific service.
+`off_board_payment`	   | Boolean indicating if there are fare gates or tagging stations before the platform.  Can be overriden by [`stop_times_ft.txt`](stop_times_ft.md) value for a specific service.
 `number_loading_areas` | Integer indicating the number of bus berths at the stop or station. This is a TCQSM parameter used to calculate dwell time.
 

--- a/files/vehicles_ft.md
+++ b/files/vehicles_ft.md
@@ -30,13 +30,13 @@ File MAY contain the following attributes:
 | | `CNG`
 |	| `electric-trolly`
 | `wheelchair_capacity`	| Integer. Total capacity for wheelchairs on vehicle. Overrides value in [`trips.txt`](trips.md) file.  
-|	| `Blank` - indicates that it is unknown and is treated as infinite unless the trip file says that it is not bicycle accessible.  
+|	| `Blank` - indicates that it is unknown and is treated as infinite.  
 | | `0`  - indicates that wheelchairs cannot access this vehicle.
-| | `1+` - number of wheelchairs that can be accommodated
-| `bicycle_capacity`		| Integer.  Number of _non-folding_ bicycles that can be accommodated.  Overrides value in [`trips.txt`](trips.md) file.
+| | `1+` - number of wheelchairs that can be accommodated.
+| `bicycle_capacity`		| Integer.  Number of _non-folding_ bicycles that can be accommodated.
 |	| `Blank` - indicates that it is unknown and is treated as infinite unless the trip file says that it is not bicycle accessible.
 |	| `0`  - indicates that bicycles cannot ride on this vehicle.
-|	| `1+` - number of bicycles that can be accommodated
+|	| `1+` - number of bicycles that can be accommodated.
 | `boarding_door` | String value identifying the door(s) used for boarding. This is a TCQSM parameter used to calculate dwell time.
 | | `Blank` - indicates that it is unknown, assumed to be front door boarding
 | | `front` - indicates boarding is only allowed at the front door
@@ -56,6 +56,6 @@ File MAY contain the following attributes:
 | | `stairs` - indicates the bus floor is above the loading platform height, and/or there are stairs from the door to the bus floor.
 | | `steep_stairs` - indicates there are steep stairs to a bus floor, as typically found on a high-floor commuter bus.
 | `door_time` | Integer representation of seconds for doors to open and close, usually between 2 and 5 seconds. This is a TCQSM parameter used to calculate dwell time.
-| `acceleration` | Float value indicating the acceleration of the vehicle in miles/hour/second
-| `deceleration` | Float value indicating the deceleration of the vehicle in miles/hour/second
-| `dwell_formula` | String value. Can specify a scalar in seconds(e.g., 0, 30), an equation based on boards and alights that returns seconds, or a string to specify a default calculation type (e.g., "TCQSM" to refer to the Transit Capacity and Quality of Service Manual). If the column or value are left blank, or specified as `static`, no assumption about dwell time is made.
+| `acceleration` | Float. alue indicating the acceleration of the vehicle in miles/hour/second
+| `deceleration` | Float. Value indicating the deceleration of the vehicle in miles/hour/second
+| `dwell_formula` | String. Can specify a scalar in seconds(e.g., 0, 30), an equation based on boards and alights that returns seconds, or a string to specify a default calculation type (e.g., "TCQSM" to refer to the Transit Capacity and Quality of Service Manual). If the column or value are left blank, or specified as `static`, no assumption about dwell time is made.

--- a/files/vehicles_ft.md
+++ b/files/vehicles_ft.md
@@ -10,30 +10,30 @@ File MUST contain the following attributes:
 
 Required Attributes	| Description										
 ----------			| -------------		
-`vehicle_name`		| String that uniquely identifies vehicle type
+`vehicle_name`		| String. Uniquely identifies vehicle type
 
 File MAY contain the following attributes:
 
 |Optional Attributes		| Description										
 | ----------				| -------------		
-| `vehicle_description`	| String description of the vehicle. For example, "metro-articulated"
-| `seated_capacity`		| Integer of total seated capacity per vehicle. 
-| `standing_capacity`	| Integer of number of standing riders at capacity.  
-| `number_of_doors`		| Integer of number of doors.
-| `max_speed`			| Float of the maximum speed of the vehicle in miles per hour.
-| `vehicle_length`		| Float of the vehicle length in feet.
-| `platform_height`		| Float of the platform height in inches.
-| `propulsion_type`		| String of the name of the propulsion type.  Possible values include:
+| `vehicle_description`	| String. Description of the vehicle. For example, "metro-articulated"
+| `seated_capacity`		| Integer. Total seated capacity per vehicle. 
+| `standing_capacity`	| Integer. Number of standing riders at capacity.  
+| `number_of_doors`		| Integer. Number of doors.
+| `max_speed`			| Float. Maximum speed of the vehicle in miles per hour.
+| `vehicle_length`		| Float. Vehicle length in feet.
+| `platform_height`		| Float. Platform height in inches.
+| `propulsion_type`		| String. Name of the propulsion type.  Possible values include:
 |	| `diesel`
 | | `bio-diesel`
 | | `diesel-hybrid`
 | | `CNG`
 |	| `electric-trolly`
-| `wheelchair_capacity`	| Integer of total capacity for wheelchairs on vehicle. Overrides value in trip file.  
-|	| `Blank` - indicates that it is unknown and is treated as infinite.  
+| `wheelchair_capacity`	| Integer. Total capacity for wheelchairs on vehicle. Overrides value in [`trips.txt`](trips.md) file.  
+|	| `Blank` - indicates that it is unknown and is treated as infinite unless the trip file says that it is not bicycle accessible.  
 | | `0`  - indicates that wheelchairs cannot access this vehicle.
 | | `1+` - number of wheelchairs that can be accommodated
-| `bicycle_capacity`		| Integer representation of [non-folding] bicycles that can be accommodated.  
+| `bicycle_capacity`		| Integer.  Number of _non-folding_ bicycles that can be accommodated.  Overrides value in [`trips.txt`](trips.md) file.
 |	| `Blank` - indicates that it is unknown and is treated as infinite unless the trip file says that it is not bicycle accessible.
 |	| `0`  - indicates that bicycles cannot ride on this vehicle.
 |	| `1+` - number of bicycles that can be accommodated


### PR DESCRIPTION
**Two "structural" changes to the spec:**
1. README file did not mention `fare_attributes.txt` at all, even though we include it in the repository.  Added this file to table of optional files, with footnote below to clarify.
2. GTFS spec now has `agency_email` as an optional field in `agency.txt`; added this to GTFS-PLUS spec for consistency.

**Plus various edits throughout to address:**
- Minor corrections to fare example tables for consistency with latest spec.
- Cleaned up stray references to old files & fields that have been updated in latest spec.
- Misc typos, spelling, capitalization, punctuation.
- Added / corrected links to other files in the repo.
- Added / corrected links to external data standards (e.g., currency codes).
- Some markdown edits for cleaner table display.